### PR TITLE
Add a test case that exibits over-capacity out-of-memory error

### DIFF
--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -204,3 +204,9 @@ fn roundtrip_tag_fancier_data() {
         value: vec![1, 2, 3, 4, 5],
     }));
 }
+
+#[test]
+fn test_oom() {
+   let bad = vec![155u8, 0x00, 0xFF, 0xFF, 0xFF, 0x00, 0xFF, 0xFF, 0xFF];
+   let _: Vec<u32> = decode(&bad[..]);
+}


### PR DESCRIPTION
This is exactly the same class of error that has hit bincode recently.
https://github.com/TyOverby/bincode/issues/41

I have [an issue](https://github.com/rust-lang/rustc-serialize/issues/115) with [a solution](https://github.com/TyOverby/rustc-serialize/commit/cb9dab6b4d4cb7518513537c52397e8d4fd40cd9) open on rustc-serialize.
