### PR TITLE
Initial support for serde

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,11 @@ name = "cbor"
 [dependencies]
 byteorder = "*"
 rustc-serialize = "*"
+serde = "*"
+serde_macros = "*"
 
 [dev-dependencies]
 quickcheck = "*"
 rand = "*"
+serde_json = "*"
+serde_macros = "*"

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -9,20 +9,14 @@ use cbor::{Decoder, DirectDecoder, Encoder};
 use rustc_serialize::{Decodable, Encodable};
 use rustc_serialize::json::{self, Json, ToJson};
 
-fn cbor_encode<T: Encodable>(v: T) -> Vec<u8> {
-    let mut enc = Encoder::from_memory();
-    enc.encode(&[v]).unwrap();
-    enc.as_bytes().to_vec()
-}
-
 #[bench]
 fn encode_small_cbor(b: &mut test::Bencher) {
     let data = ("hello, world".to_string(),
                 true, (), vec![1, 1000, 100_000, 10_000_000], 3.14);
 
-    b.bytes = cbor_encode(&data).len() as u64;
+    b.bytes = cbor::encode(&data).len() as u64;
     b.iter(|| {
-        cbor_encode(&data);
+        cbor::encode(&data);
     });
 }
 
@@ -54,9 +48,9 @@ fn encode_medium_cbor(b: &mut test::Bencher) {
                 true, (), vec![1, 1000, 100_000, 10_000_000], 3.14);
     let items = repeat(&data).take(10_000).collect::<Vec<_>>();
 
-    b.bytes = cbor_encode(&items).len() as u64;
+    b.bytes = cbor::encode(&items).len() as u64;
     b.iter(|| {
-        cbor_encode(&items);
+        cbor::encode(&items);
     });
 }
 

--- a/src/deserializer.rs
+++ b/src/deserializer.rs
@@ -1,0 +1,535 @@
+use std::io::{self, Read};
+
+use byteorder::{ReadBytesExt, BigEndian};
+use rustc_serialize::Decoder as RustcDecoder;
+use serde::{self, Deserialize};
+use serde::de;
+
+use {Type, CborResult, CborError, ReadError};
+
+/// Experimental and incomplete direct decoder.
+///
+/// A "direct" decoder is one that does not use an intermediate abstact syntax
+/// representation. Namely, the bytes are decoded directly into types. This
+/// *significantly* impacts performance. For example, it doesn't have to box
+/// and unbox every data item.
+///
+/// However, implementing a direct decoder is much harder in the existing
+/// serialization infrastructure. Currently, structs and enums are not
+/// implemented. (But `Vec`s, tuples, `Option`s and maps should work.)
+pub struct Deserializer<R> {
+    rdr: CborReader<R>,
+    first: Option<u8>,
+}
+
+impl<R: io::Read> Deserializer<R> {
+    /// Create a new CBOR deserializer from the underlying reader.
+    pub fn from_reader(rdr: R) -> Deserializer<io::BufReader<R>> {
+        Deserializer {
+            rdr: CborReader::new(io::BufReader::new(rdr)),
+            first: None,
+        }
+    }
+}
+
+impl Deserializer<io::Cursor<Vec<u8>>> {
+    /// Create a new CBOR decoder that reads from the buffer given.
+    ///
+    /// The buffer is usually given as either a `Vec<u8>` or a `&[u8]`.
+    pub fn from_bytes<'a, T>(bytes: T) -> Deserializer<io::Cursor<Vec<u8>>>
+            where T: Into<Vec<u8>> {
+        Deserializer {
+            rdr: CborReader::new(io::Cursor::new(bytes.into())),
+            first: None,
+        }
+    }
+}
+
+
+impl<R: io::Read> Deserializer<R> {
+    fn errat(&self, err: ReadError) -> CborError {
+        CborError::AtOffset { kind: err, offset: self.rdr.last_offset }
+    }
+
+    fn errstr(&self, s: String) -> CborError {
+        self.errat(ReadError::Other(s))
+    }
+
+    fn err(&self, err: ReadError) -> CborError {
+        CborError::Decode(err)
+    }
+
+    fn miss(&self, expected: Type, got: u8) -> CborError {
+        self.err(ReadError::miss(expected, got))
+    }
+
+    fn peek_marker(&mut self) -> CborResult<u8> {
+        match self.first {
+            Some(value) => Ok(value),
+            None => {
+                let first = try!(self.rdr.read_u8());
+                self.first = Some(first);
+                Ok(first)
+            }
+        }
+    }
+
+    fn read_marker(&mut self) -> CborResult<u8> {
+        match self.first.take() {
+            Some(value) => Ok(value),
+            None => Ok(try!(self.rdr.read_u8())),
+        }
+    }
+
+    fn read_value<V>(&mut self, first: u8, visitor: V) -> CborResult<V::Value>
+        where V: serde::de::Visitor,
+    {
+        match (first & 0b111_00000) >> 5 {
+            0 => self.read_usize(first, visitor),
+            1 => self.read_isize(first, visitor),
+            2 => self.read_bytes(first, visitor),
+            3 => self.read_string(first, visitor),
+            4 => self.read_array(first, visitor),
+            5 => self.read_map(first, visitor),
+            6 => self.read_tag(first, visitor),
+            7 => match first & 0b000_11111 {
+                v @ 0...23 => self.read_simple_value(v, visitor),
+                24 => {
+                    let b = try!(self.rdr.read_u8());
+                    self.read_simple_value(b, visitor)
+                }
+                25...27 => self.read_float(first, visitor),
+                v @ 28...30 =>
+                    Err(self.errat(
+                        ReadError::Unassigned { major: 7, add: v })),
+                //31 => Ok(Cbor::Break),
+                // Because max(byte & 0b000_11111) == 2^5 - 1 == 31
+                _ => {
+                    unreachable!("bah2 {} {} {}", first, (first & 0b111_00000) >> 5, first & 0b000_11111);
+                    //unreachable!()
+                }
+            },
+            // This is truly unreachable because `byte & 0b111_00000 >> 5`
+            // can only produce 8 distinct values---each of which are handled
+            // above. ---AG
+            _ => {
+                unreachable!("bah! {} {}", first, (first & 0b111_00000) >> 5);
+                //unreachable!()
+            }
+        }
+    }
+
+    fn read_len(&mut self, first: u8) -> CborResult<usize> {
+        self.read_usize(first, serde::de::impls::PrimitiveVisitor::new())
+    }
+
+    fn read_type(&mut self, first: u8, expected: Type) -> CborResult<u8> {
+        if (first & 0b111_00000) >> 5 == expected.major() {
+            Ok(first)
+        } else {
+            Err(self.miss(expected, first))
+        }
+    }
+
+    fn read_simple_value<V>(&mut self, val: u8, mut visitor: V) -> CborResult<V::Value>
+        where V: serde::de::Visitor,
+    {
+        match val {
+            v @ 0...19 =>
+                Err(self.errat(
+                    ReadError::Unassigned { major: 7, add: v })),
+            20 => visitor.visit_bool(false),
+            21 => visitor.visit_bool(true),
+            22 => visitor.visit_unit(),
+            23 => panic!("unimplemented"),
+            //23 => Cbor::Undefined,
+            v @ 24...31 =>
+                Err(self.errat(
+                    ReadError::Reserved { major: 7, add: v })),
+            v /* 32...255 */ =>
+                Err(self.errat(
+                    ReadError::Unassigned { major: 7, add: v })),
+        }
+    }
+
+    fn read_float<V>(&mut self, first: u8, mut visitor: V) -> CborResult<V::Value>
+        where V: serde::de::Visitor,
+    {
+        match ((first & 0b111_00000) >> 5, first & 0b000_11111) {
+            (0, n) => {
+                self.read_usize(n, visitor)
+            }
+            (1, n) => {
+                self.read_isize(n, visitor)
+            }
+            (7, 25) => {
+                // Rust doesn't have a `f16` type, so just read a u16 and
+                // cast it to a f64. I think this is wrong. ---AG
+                visitor.visit_f64(try!(self.rdr.read_u16::<BigEndian>()) as f64)
+            }
+            (7, 26) => {
+                visitor.visit_f32(try!(self.rdr.read_f32::<BigEndian>()))
+            }
+            (7, 27) => {
+                visitor.visit_f64(try!(self.rdr.read_f64::<BigEndian>()))
+            }
+            _ => Err(self.miss(Type::Float, first)),
+        }
+    }
+
+    fn read_isize<V>(&mut self, first: u8, mut visitor: V) -> CborResult<V::Value>
+        where V: serde::de::Visitor,
+    {
+        match first & 0b000_11111 {
+            n @ 0...23 => visitor.visit_i8(-1 - (n as i8)),
+            24 => {
+                let n = try!(self.rdr.read_u8());
+                if n > ::std::i8::MAX as u8 {
+                    visitor.visit_i16(-1 - (n as i16))
+                } else {
+                    visitor.visit_i8(-1 - (n as i8))
+                }
+            }
+            25 => {
+                let n = try!(self.rdr.read_u16::<BigEndian>());
+                if n > ::std::i16::MAX as u16 {
+                    visitor.visit_i32(-1 - (n as i32))
+                } else {
+                    visitor.visit_i16(-1 - (n as i16))
+                }
+            }
+            26 => {
+                let n = try!(self.rdr.read_u32::<BigEndian>());
+                if n > ::std::i32::MAX as u32 {
+                    visitor.visit_i64(-1 - (n as i64))
+                } else {
+                    visitor.visit_i32(-1 - (n as i32))
+                }
+            }
+            27 => {
+                let n = try!(self.rdr.read_u64::<BigEndian>());
+                if n > ::std::i64::MAX as u64 {
+                    return Err(self.errstr(format!(
+                        "Negative integer out of range: {:?}", n)));
+                }
+                visitor.visit_i64(-1 - (n as i64))
+            }
+            v => Err(self.errat(
+                ReadError::InvalidAddValue { ty: Type::Int, val: v })),
+        }
+    }
+
+    fn read_usize<V>(&mut self, first: u8, mut visitor: V) -> CborResult<V::Value>
+        where V: serde::de::Visitor,
+    {
+        match first & 0b000_11111 {
+            n @ 0...23 => visitor.visit_u8(n),
+            24 => visitor.visit_u8(try!(self.rdr.read_u8())),
+            25 => visitor.visit_u16(try!(self.rdr.read_u16::<BigEndian>())),
+            26 => visitor.visit_u32(try!(self.rdr.read_u32::<BigEndian>())),
+            27 => visitor.visit_u64(try!(self.rdr.read_u64::<BigEndian>())),
+            v => Err(self.errat(
+                ReadError::InvalidAddValue { ty: Type::UInt, val: v })),
+        }
+    }
+
+    fn read_tag<V>(&mut self, first: u8, visitor: V) -> CborResult<V::Value>
+        where V: serde::de::Visitor,
+    {
+        self.read_usize(first, visitor)
+    }
+
+    fn read_map<V>(&mut self, first: u8, mut visitor: V) -> CborResult<V::Value>
+        where V: serde::de::Visitor,
+    {
+        let len = try!(self.read_len(first));
+        visitor.visit_map(MapVisitor {
+            deserializer: self,
+            len: len,
+        })
+    }
+
+    fn read_array<V>(&mut self, first: u8, mut visitor: V) -> CborResult<V::Value>
+        where V: serde::de::Visitor,
+    {
+        let len = try!(self.read_len(first));
+        visitor.visit_seq(SeqVisitor {
+            deserializer: self,
+            len: len,
+        })
+    }
+
+    fn read_string<V>(&mut self, first: u8, mut visitor: V) -> CborResult<V::Value>
+        where V: serde::de::Visitor,
+    {
+        let b = try!(self.read_type(first, Type::Unicode));
+        let len = try!(self.read_len(b));
+        let mut buf = vec_from_elem(len, 0);
+        try!(self.rdr.read_full(&mut buf));
+
+        let string = match String::from_utf8(buf) {
+            Ok(string) => string,
+            Err(err) => { return Err(self.errstr(err.utf8_error().to_string())); }
+        };
+
+        visitor.visit_string(string)
+    }
+
+    fn read_bytes<V>(&mut self, first: u8, mut visitor: V) -> CborResult<V::Value>
+        where V: serde::de::Visitor,
+    {
+        let len = try!(self.read_len(first));
+        let mut buf = vec_from_elem(len, 0);
+        try!(self.rdr.read_full(&mut buf));
+        visitor.visit_byte_buf(buf)
+    }
+}
+
+struct SeqVisitor<'a, R: 'a> {
+    deserializer: &'a mut Deserializer<R>,
+    len: usize,
+}
+
+impl<'a, R> serde::de::SeqVisitor for SeqVisitor<'a, R>
+    where R: io::Read,
+{
+    type Error = CborError;
+
+    fn visit<T>(&mut self) -> CborResult<Option<T>>
+        where T: serde::Deserialize,
+    {
+        if self.len == 0 {
+            Ok(None)
+        } else {
+            self.len -= 1;
+            Ok(Some(try!(Deserialize::deserialize(self.deserializer))))
+        }
+    }
+
+    fn end(&mut self) -> CborResult<()> {
+        if self.len == 0 {
+            Ok(())
+        } else {
+            Err(self.deserializer.errstr("Unexpected end of array".to_string()))
+        }
+    }
+}
+
+struct MapVisitor<'a, R: 'a> {
+    deserializer: &'a mut Deserializer<R>,
+    len: usize,
+}
+
+impl<'a, R> serde::de::MapVisitor for MapVisitor<'a, R>
+    where R: io::Read,
+{
+    type Error = CborError;
+
+    fn visit_key<T>(&mut self) -> CborResult<Option<T>>
+        where T: serde::Deserialize,
+    {
+        if self.len == 0 {
+            Ok(None)
+        } else {
+            self.len -= 1;
+            // FIXME: make sure field is unicode
+            Ok(Some(try!(Deserialize::deserialize(self.deserializer))))
+        }
+    }
+
+    fn visit_value<T>(&mut self) -> CborResult<T>
+        where T: serde::Deserialize,
+    {
+        Ok(try!(Deserialize::deserialize(self.deserializer)))
+    }
+
+    fn end(&mut self) -> CborResult<()> {
+        if self.len == 0 {
+            Ok(())
+        } else {
+            Err(self.deserializer.errstr("Unexpected end of array".to_string()))
+        }
+    }
+}
+
+impl<R> serde::Deserializer for Deserializer<R>
+    where R: io::Read,
+{
+    type Error = CborError;
+
+    fn visit<V>(&mut self, visitor: V) -> CborResult<V::Value>
+        where V: serde::de::Visitor,
+    {
+        let first = try!(self.read_marker());
+        self.read_value(first, visitor)
+    }
+
+    fn visit_struct<V>(&mut self,
+                       name: &str,
+                       _fields: &[&str],
+                       visitor: V) -> CborResult<V::Value>
+        where V: serde::de::Visitor,
+    {
+        match name {
+            "CborTag" => {
+                let first = try!(self.read_marker());
+                match (first & 0b111_00000) >> 5 {
+                    //6 => self.read_tag(first, visitor),
+                    _ => panic!("visit_named_enum")
+                }
+            }
+            _ => self.visit(visitor),
+        }
+    }
+
+    fn visit_enum<V>(&mut self,
+                     _name: &str,
+                     _variants: &[&str],
+                     mut visitor: V) -> CborResult<V::Value>
+        where V: serde::de::EnumVisitor,
+    {
+        let first = try!(self.peek_marker());
+
+        match (first & 0b111_00000) >> 5 {
+            3 => {
+                visitor.visit(StringVariantVisitor {
+                    de: self,
+                })
+            }
+            5 => {
+                self.first = None;
+
+                let len = try!(self.read_len(first));
+                if len != 1 {
+                    return Err(self.errstr(String::from("Too many fields in variant map")));
+                }
+
+                visitor.visit(self)
+            }
+            _ => {
+                return Err(self.errstr(String::from("Expected variant map")));
+            }
+        }
+    }
+}
+
+struct StringVariantVisitor<'a, R: io::Read + 'a> {
+    de: &'a mut Deserializer<R>,
+}
+
+impl<'a, R: io::Read> de::VariantVisitor for StringVariantVisitor<'a, R> {
+    type Error = CborError;
+
+    fn visit_variant<V>(&mut self) -> CborResult<V>
+        where V: de::Deserialize
+    {
+        de::Deserialize::deserialize(self.de)
+    }
+
+    fn visit_unit(&mut self) -> CborResult<()> {
+        Ok(())
+    }
+}
+
+impl<R: io::Read> de::VariantVisitor for Deserializer<R> {
+    type Error = CborError;
+
+    fn visit_variant<V>(&mut self) -> CborResult<V>
+        where V: de::Deserialize
+    {
+        de::Deserialize::deserialize(self)
+    }
+
+    fn visit_unit(&mut self) -> CborResult<()> {
+        de::Deserialize::deserialize(self)
+    }
+
+    fn visit_newtype<T>(&mut self) -> CborResult<T>
+        where T: de::Deserialize,
+    {
+        de::Deserialize::deserialize(self)
+    }
+
+    fn visit_tuple<V>(&mut self,
+                      _len: usize,
+                      visitor: V) -> CborResult<V::Value>
+        where V: de::Visitor,
+    {
+        de::Deserializer::visit(self, visitor)
+    }
+
+    fn visit_struct<V>(&mut self,
+                       _fields: &'static [&'static str],
+                       visitor: V) -> CborResult<V::Value>
+        where V: de::Visitor,
+    {
+        de::Deserializer::visit(self, visitor)
+    }
+}
+
+/// A very light layer over a basic reader that keeps track of offset
+/// information at the byte level.
+struct CborReader<R> {
+    rdr: R,
+    // read from here before going back to rdr
+    buf: Vec<u8>,
+    // used for error reporting
+    last_offset: usize,
+    bytes_read: usize,
+}
+
+impl<R: io::Read> io::Read for CborReader<R> {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        if !self.buf.is_empty() {
+            if self.buf.len() <= buf.len() {
+                let nread = self.buf.len();
+                for (i, &x) in self.buf.iter().enumerate() {
+                    buf[i] = x;
+                }
+                self.buf.truncate(0);
+                Ok(nread)
+            } else {
+                for (i, x) in buf.iter_mut().enumerate() {
+                    *x = self.buf[i];
+                }
+                for (i0, i1) in (0..).zip(buf.len()..self.buf.len()) {
+                    self.buf[i0] = self.buf[i1];
+                }
+                let new_len = self.buf.len() - buf.len();
+                self.buf.truncate(new_len);
+                Ok(buf.len())
+            }
+        } else {
+            let n = try!(self.rdr.read(buf));
+            self.last_offset = self.bytes_read;
+            self.bytes_read += n;
+            Ok(n)
+        }
+    }
+}
+
+impl<R: io::Read> CborReader<R> {
+    fn new(rdr: R) -> CborReader<R> {
+        CborReader {
+            rdr: rdr,
+            buf: Vec::with_capacity(1 << 16),
+            last_offset: 0,
+            bytes_read: 0,
+        }
+    }
+
+    fn read_full(&mut self, buf: &mut [u8]) -> CborResult<()> {
+        let mut n = 0usize;
+        while n < buf.len() {
+            n += try!(self.read(&mut buf[n..]));
+        }
+        Ok(())
+    }
+}
+
+fn vec_from_elem<T: Copy>(len: usize, v: T) -> Vec<T> {
+    let mut xs = Vec::with_capacity(len);
+    unsafe { xs.set_len(len); }
+    for x in &mut xs { *x = v; }
+    xs
+}

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -269,10 +269,8 @@ impl<W: io::Write> RustcEncoder for Encoder<W> {
             return self.emit_str(v_name);
         }
         no_string_key!(self);
-        try!(self.write_num(5, 2));
-        try!(self.emit_str("variant"));
+        try!(self.write_num(5, 1));
         try!(self.emit_str(v_name));
-        try!(self.emit_str("fields"));
         try!(self.write_num(4, len as u64));
         f(self)
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -862,3 +862,26 @@ mod encoder;
 mod json;
 mod rustc_decoder;
 mod rustc_decoder_direct;
+
+/// Encode a CBOR value into a Vec<u8>.
+pub fn encode<T: Encodable>(v: T) -> Vec<u8> {
+    let mut ser = Encoder::from_memory();
+    ser.encode(&[v]).unwrap();
+    ser.as_bytes().to_vec()
+}
+
+/// Encode a CBOR value into a writer.
+pub fn encode_into<W: io::Write, T: Encodable>(wr: W, v: T) -> CborResult<()> {
+    let mut ser = Encoder::from_writer(wr);
+    ser.encode(&[v])
+}
+
+/// Decode a CBOR value from a `&[u8]`.
+pub fn decode<T: Decodable>(bytes: &[u8]) -> CborResult<T> {
+    Decoder::from_bytes(bytes).decode().next().unwrap()
+}
+
+/// Decode a CBOR value from a reader.
+pub fn decode_from<R: io::Read, T: Decodable>(rdr: R) -> CborResult<T> {
+    Decoder::from_reader(rdr).decode().next().unwrap()
+}

--- a/src/serializer.rs
+++ b/src/serializer.rs
@@ -1,0 +1,411 @@
+use std::iter::IntoIterator;
+use std::io;
+use std::u8;
+use std::u16;
+use std::u32;
+
+use byteorder::{ByteOrder, BigEndian};
+use serde::{self, Serialize};
+
+use {CborError, CborResult, Type, WriteError};
+
+/// Serializes Rust values to CBOR bytes in the underlying writer `W`.
+///
+/// Note that currently, using the serialization infrastructure is the only
+/// way to write CBOR in this crate.
+pub struct Serializer<W> {
+    buf: W,
+    emitting_key: bool,
+    byte_string: bool,
+    tag: bool,
+    skip_key: bool,
+}
+
+impl<W: io::Write> Serializer<W> {
+    fn write_num(&mut self, major: u8, n: u64) -> CborResult<()> {
+        let major = major << 5;
+        if n <= 23 {
+            fromerr!(self.buf.write_all(&[major | n as u8]))
+        } else if n <= u8::MAX as u64 {
+            fromerr!(self.buf.write_all(&[major | 24, n as u8]))
+        } else if n <= u16::MAX as u64 {
+            let mut buf = [major | 25, 0, 0];
+            <BigEndian as ByteOrder>::write_u16(&mut buf[1..], n as u16);
+            fromerr!(self.buf.write_all(&buf))
+        } else if n <= u32::MAX as u64 {
+            let mut buf = [major | 26, 0, 0, 0, 0];
+            <BigEndian as ByteOrder>::write_u32(&mut buf[1..], n as u32);
+            fromerr!(self.buf.write_all(&buf))
+        } else {
+            let mut buf = [major | 27, 0, 0, 0, 0, 0, 0, 0, 0];
+            <BigEndian as ByteOrder>::write_u64(&mut buf[1..], n);
+            fromerr!(self.buf.write_all(&buf))
+        }
+    }
+
+    fn write_uint(&mut self, n: u64) -> CborResult<()> {
+        self.write_num(0, n)
+    }
+
+    fn write_int(&mut self, n: i64) -> CborResult<()> {
+        if n >= 0 {
+            self.write_uint(n as u64)
+        } else {
+            self.write_num(1, (-1 - n) as u64)
+        }
+    }
+}
+
+impl<W: io::Write> Serializer<W> {
+    /// Serialize CBOR to an arbitrary writer.
+    pub fn from_writer(wtr: W) -> Serializer<io::BufWriter<W>> {
+        Serializer::from_writer_raw(io::BufWriter::new(wtr))
+    }
+
+    fn from_writer_raw(wtr: W) -> Serializer<W> {
+        Serializer {
+            buf: wtr,
+            emitting_key: false,
+            byte_string: false,
+            tag: false,
+            skip_key: false,
+        }
+    }
+
+    /// Serialize an iterator of Rust values to CBOR in the underlying writer.
+    ///
+    /// Every value in the iterator must satisfy `Serialize` (from the
+    /// `serde` crate).
+    ///
+    /// Note that this serializes top-level CBOR data items. They can be decoded
+    /// in a streaming fashion.
+    ///
+    /// # Example
+    ///
+    /// Serialize a list of numbers.
+    ///
+    /// ```rust
+    /// use cbor::Serializer;
+    ///
+    /// let mut ser = Serializer::from_memory();
+    /// ser.serialize(&[1, 2, 3, 4, 5]);
+    /// assert_eq!(vec![1, 2, 3, 4, 5], ser.as_bytes());
+    /// ```
+    pub fn serialize<I, T>(&mut self, it: I) -> CborResult<()>
+        where I: IntoIterator<Item=T>,
+              T: Serialize {
+        for v in it {
+            try!(v.serialize(self));
+        }
+        Ok(())
+    }
+
+    /// Flush the underlying writer.
+    pub fn flush(&mut self) -> CborResult<()> {
+        fromerr!(self.buf.flush())
+    }
+}
+
+impl Serializer<Vec<u8>> {
+    /// Serialize CBOR to an in memory buffer.
+    pub fn from_memory() -> Serializer<Vec<u8>> {
+        Serializer::from_writer_raw(Vec::with_capacity(1024 * 64))
+    }
+
+    /// Flush and retrieve the CBOR bytes that have been written.
+    pub fn as_bytes(&mut self) -> &[u8] {
+        self.flush().unwrap();
+        &self.buf
+    }
+
+    /// Flush and retrieve the CBOR bytes that have been written without
+    /// copying.
+    pub fn into_bytes(mut self) -> Vec<u8> {
+        self.flush().unwrap();
+        self.buf
+    }
+}
+
+// /// Encodes a data item directly to CBOR bytes.
+// ///
+// /// This is useful when writing `Encodable` implementations with
+// /// `CborTagEncode`.
+// pub fn encode<E: Encodable>(v: E) -> CborResult<Vec<u8>> {
+    // let mut enc = Encoder::from_memory();
+    // try!(enc.encode(&[v]));
+    // Ok(enc.into_bytes())
+// }
+
+macro_rules! no_string_key {
+    ($enc:expr) => (
+        if $enc.emitting_key {
+            return Err(CborError::Encode(WriteError::InvalidMapKey {
+                got: None,
+            }));
+        }
+    );
+    ($enc:expr, $ty:expr) => (
+        if $enc.emitting_key {
+            return Err(CborError::Encode(WriteError::InvalidMapKey {
+                got: Some($ty),
+            }));
+        }
+    );
+}
+
+impl<W: io::Write> serde::Serializer for Serializer<W> {
+    type Error = CborError;
+
+    fn visit_unit(&mut self) -> CborResult<()> {
+        no_string_key!(self, Type::Null);
+        fromerr!(self.buf.write_all(&[(7 << 5) | 22]))
+    }
+
+    fn visit_usize(&mut self, v: usize) -> CborResult<()> {
+        no_string_key!(self, Type::UInt);
+        self.write_uint(v as u64)
+    }
+
+    fn visit_u64(&mut self, v: u64) -> CborResult<()> {
+        no_string_key!(self, Type::UInt64);
+        if self.tag {
+            self.write_num(6, v)
+        } else {
+            self.write_uint(v)
+        }
+    }
+
+    fn visit_u32(&mut self, v: u32) -> CborResult<()> {
+        no_string_key!(self, Type::UInt32);
+        self.write_uint(v as u64)
+    }
+
+    fn visit_u16(&mut self, v: u16) -> CborResult<()> {
+        no_string_key!(self, Type::UInt16);
+        self.write_uint(v as u64)
+    }
+
+    fn visit_u8(&mut self, v: u8) -> CborResult<()> {
+        no_string_key!(self, Type::UInt8);
+        if self.byte_string {
+            fromerr!(self.buf.write_all(&[v]))
+        } else {
+            self.write_uint(v as u64)
+        }
+    }
+
+    fn visit_isize(&mut self, v: isize) -> CborResult<()> {
+        no_string_key!(self, Type::Int);
+        self.write_int(v as i64)
+    }
+
+    fn visit_i64(&mut self, v: i64) -> CborResult<()> {
+        no_string_key!(self, Type::Int64);
+        self.write_int(v)
+    }
+
+    fn visit_i32(&mut self, v: i32) -> CborResult<()> {
+        no_string_key!(self, Type::Int32);
+        self.write_int(v as i64)
+    }
+
+    fn visit_i16(&mut self, v: i16) -> CborResult<()> {
+        no_string_key!(self, Type::Int16);
+        self.write_int(v as i64)
+    }
+
+    fn visit_i8(&mut self, v: i8) -> CborResult<()> {
+        no_string_key!(self, Type::Int8);
+        self.write_int(v as i64)
+    }
+
+    fn visit_f64(&mut self, v: f64) -> CborResult<()> {
+        no_string_key!(self, Type::Float64);
+        let mut buf = [(7 << 5) | 27, 0, 0, 0, 0, 0, 0, 0, 0];
+        <BigEndian as ByteOrder>::write_f64(&mut buf[1..], v);
+        fromerr!(self.buf.write_all(&buf))
+    }
+
+    fn visit_f32(&mut self, v: f32) -> CborResult<()> {
+        no_string_key!(self, Type::Float32);
+        let mut buf = [(7 << 5) | 26, 0, 0, 0, 0];
+        <BigEndian as ByteOrder>::write_f32(&mut buf[1..], v);
+        fromerr!(self.buf.write_all(&buf))
+    }
+
+    fn visit_bool(&mut self, v: bool) -> CborResult<()> {
+        no_string_key!(self, Type::Bool);
+        let n = if v { 21 } else { 20 };
+        fromerr!(self.buf.write_all(&[(7 << 5) | n]))
+    }
+
+    fn visit_char(&mut self, v: char) -> CborResult<()> {
+        no_string_key!(self, Type::UInt32);
+        self.visit_u32(v as u32)
+    }
+
+    fn visit_str(&mut self, v: &str) -> CborResult<()> {
+        try!(self.write_num(3, v.len() as u64));
+        fromerr!(self.buf.write_all(v.as_bytes()))
+    }
+
+    fn visit_none(&mut self) -> CborResult<()> {
+        no_string_key!(self);
+        self.visit_unit()
+    }
+
+    fn visit_some<T>(&mut self, value: T) -> CborResult<()>
+        where T: Serialize,
+    {
+        no_string_key!(self);
+        value.serialize(self)
+    }
+
+    fn visit_unit_variant(&mut self,
+                          _name: &str,
+                          _variant_index: usize,
+                          variant: &str) -> CborResult<()> {
+        self.visit_str(variant)
+    }
+
+    fn visit_seq<V>(&mut self, mut visitor: V) -> CborResult<()>
+        where V: serde::ser::SeqVisitor,
+    {
+        no_string_key!(self, Type::Array);
+
+        let len = visitor.len().unwrap();
+
+        if self.byte_string {
+            try!(self.write_num(2, len as u64));
+        } else {
+            try!(self.write_num(4, len as u64));
+        }
+
+        while let Some(()) = try!(visitor.visit(self)) { }
+
+        self.byte_string = false;
+
+        Ok(())
+    }
+
+    fn visit_tuple_struct<V>(&mut self,
+                             name: &str,
+                             mut visitor: V) -> CborResult<()>
+        where V: serde::ser::SeqVisitor,
+    {
+        no_string_key!(self, Type::Map);
+
+        let len = visitor.len().unwrap();
+
+        match name {
+            "CborBytes" => {
+                self.byte_string = true;
+            }
+            _ => {
+                try!(self.write_num(4, len as u64)); }
+        }
+
+        while let Some(()) = try!(visitor.visit(self)) { }
+
+        Ok(())
+    }
+
+    fn visit_tuple_variant<V>(&mut self,
+                              _name: &str,
+                              _variant_index: usize,
+                              variant: &str,
+                              mut visitor: V) -> CborResult<()>
+        where V: serde::ser::SeqVisitor,
+    {
+        no_string_key!(self);
+
+        try!(self.write_num(5, 1));
+        try!(self.visit_str(variant));
+
+        let len = visitor.len().unwrap();
+        try!(self.write_num(4, len as u64));
+
+        while let Some(()) = try!(visitor.visit(self)) { }
+
+        Ok(())
+    }
+
+    fn visit_seq_elt<T>(&mut self, value: T) -> CborResult<()>
+        where T: serde::ser::Serialize,
+    {
+        no_string_key!(self);
+        value.serialize(self)
+    }
+
+    fn visit_map<V>(&mut self, mut visitor: V) -> CborResult<()>
+        where V: serde::ser::MapVisitor,
+    {
+        no_string_key!(self, Type::Map);
+        let len = visitor.len().unwrap();
+        try!(self.write_num(5, len as u64));
+
+        while let Some(()) = try!(visitor.visit(self)) { }
+
+        Ok(())
+    }
+
+    fn visit_struct<V>(&mut self, name: &str, mut visitor: V) -> CborResult<()>
+        where V: serde::ser::MapVisitor,
+    {
+        no_string_key!(self, Type::Map);
+
+        match name {
+            "CborTag" | "CborTagEncode" => {
+                self.tag = true;
+            }
+            _ => {
+                let len = visitor.len().unwrap();
+                try!(self.write_num(5, len as u64));
+            }
+        }
+
+        while let Some(()) = try!(visitor.visit(self)) { }
+
+        Ok(())
+    }
+
+    fn visit_struct_variant<V>(&mut self,
+                               _name: &str,
+                               _variant_index: usize,
+                               variant: &str,
+                               mut visitor: V) -> CborResult<()>
+        where V: serde::ser::MapVisitor,
+    {
+        no_string_key!(self);
+
+        try!(self.write_num(5, 1));
+        try!(self.visit_str(variant));
+
+        let len = visitor.len().unwrap();
+        try!(self.write_num(4, len as u64));
+
+        self.skip_key = true;
+
+        while let Some(()) = try!(visitor.visit(self)) { }
+
+        self.skip_key = false;
+
+        Ok(())
+    }
+
+    fn visit_map_elt<K, V>(&mut self, key: K, value: V) -> CborResult<()>
+        where K: serde::Serialize,
+              V: serde::Serialize,
+    {
+        no_string_key!(self);
+
+        if !self.tag && !self.skip_key {
+            self.emitting_key = true;
+            try!(key.serialize(self));
+            self.emitting_key = false;
+        }
+
+        no_string_key!(self);
+        value.serialize(self)
+    }
+}

--- a/tests/test_serde.rs
+++ b/tests/test_serde.rs
@@ -1,0 +1,232 @@
+#![feature(custom_derive, plugin)]
+#![plugin(serde_macros)]
+
+extern crate cbor;
+extern crate quickcheck;
+extern crate rand;
+extern crate rustc_serialize;
+extern crate serde;
+
+use std::collections::HashMap;
+use std::fmt::Debug;
+use rand::thread_rng;
+use quickcheck::{QuickCheck, StdGen, Testable};
+use serde::{ser, de, Deserialize, Serialize};
+
+use cbor::{Serializer, CborBytes, CborTagEncode};
+
+fn qc_sized<A: Testable>(f: A, size: u64) {
+    QuickCheck::new()
+        .gen(StdGen::new(thread_rng(), size as usize))
+        .tests(1_00)
+        .max_tests(10_000)
+        .quickcheck(f);
+}
+
+fn round_trip<T>(v: T) -> bool
+        where T: Deserialize + Serialize + Debug + PartialEq {
+    let backv: T = cbor::deserialize(&cbor::serialize(&v)).unwrap();
+    assert_eq!(backv, v);
+    true
+}
+
+macro_rules! round_trip_num {
+    ($name:ident, $ty:ident) => (
+        #[test]
+        fn $name() {
+            #![allow(trivial_numeric_casts)]
+            fn prop(n: $ty) -> bool { round_trip(n) }
+            qc_sized(prop as fn($ty) -> bool, ::std::$ty::MAX as u64)
+        }
+    );
+}
+
+round_trip_num!(roundtrip_prop_usize, usize);
+round_trip_num!(roundtrip_prop_u64, u64);
+round_trip_num!(roundtrip_prop_u32, u32);
+round_trip_num!(roundtrip_prop_u16, u16);
+round_trip_num!(roundtrip_prop_u8, u8);
+round_trip_num!(roundtrip_prop_isize, isize);
+round_trip_num!(roundtrip_prop_i64, i64);
+round_trip_num!(roundtrip_prop_i32, i32);
+round_trip_num!(roundtrip_prop_i16, i16);
+round_trip_num!(roundtrip_prop_i8, i8);
+
+#[test]
+fn roundtrip_prop_f32() {
+    fn prop(n: f32) -> bool { round_trip(n) }
+    qc_sized(prop as fn(f32) -> bool, ::std::u64::MAX)
+}
+
+#[test]
+fn roundtrip_prop_f64() {
+    fn prop(n: f64) -> bool { round_trip(n) }
+    qc_sized(prop as fn(f64) -> bool, ::std::u64::MAX)
+}
+
+#[test]
+fn roundtrip_f32_min() {
+    round_trip(::std::f32::MIN);
+}
+
+#[test]
+fn roundtrip_f32_max() {
+    round_trip(::std::f32::MAX);
+}
+
+#[test]
+fn roundtrip_f64_min() {
+    round_trip(::std::f64::MIN);
+}
+
+#[test]
+fn roundtrip_f64_max() {
+    round_trip(::std::f64::MAX);
+}
+
+macro_rules! round_trip_any {
+    ($name:ident, $ty:ty) => (
+        #[test]
+        fn $name() {
+            fn prop(n: $ty) -> bool { round_trip(n) }
+            QuickCheck::new().quickcheck(prop as fn($ty) -> bool)
+        }
+    );
+}
+
+round_trip_any!(roundtrip_prop_nil, ());
+round_trip_any!(roundtrip_prop_bool, bool);
+round_trip_any!(roundtrip_prop_tuple, (i32, u32));
+round_trip_any!(roundtrip_prop_tuple_in_tuple, (i32, (u32, i32), u32));
+round_trip_any!(roundtrip_prop_vec, Vec<i32>);
+round_trip_any!(roundtrip_prop_vec_in_vec, Vec<Vec<i32>>);
+round_trip_any!(roundtrip_prop_map, HashMap<String, i32>);
+round_trip_any!(roundtrip_prop_vec_in_map, HashMap<String, Vec<i32>>);
+// round_trip_any!(roundtrip_prop_map_in_map,
+                // HashMap<String, HashMap<String, i32>>);
+
+#[test]
+fn roundtrip_prop_byte_string() {
+    fn prop(n: Vec<u8>) -> bool { round_trip(CborBytes(n)) }
+    QuickCheck::new().quickcheck(prop as fn(Vec<u8>) -> bool)
+}
+
+#[test]
+fn roundtrip_enum() {
+    #[derive(Debug, PartialEq, Deserialize, Serialize)]
+    enum Color { Red, Blue(String, i32), Green { s: String, n: i32 } }
+
+    round_trip(Color::Red);
+    round_trip(Color::Blue("hi".to_string(), 5));
+    round_trip(Color::Green { s: "hi".to_string(), n: 5 });
+}
+
+#[test]
+fn roundtrip_struct() {
+    #[derive(Debug, PartialEq, Deserialize, Serialize)]
+    struct Vowels { s: String, n: u32 }
+
+    round_trip(Vowels { s: "cwm".to_string(), n: 1 });
+}
+
+#[test]
+#[should_panic]
+fn invalid_map_key() {
+    let mut map = HashMap::new();
+    map.insert(5, 5);
+    cbor::serialize(map);
+}
+
+#[test]
+fn roundtrip_prop_tag() {
+    #[derive(Debug, PartialEq)]
+    struct MyTag {
+        num: u64,
+        data: Vec<i32>,
+    }
+    impl Deserialize for MyTag {
+        fn deserialize<D: de::Deserializer>(deserializer: &mut D) -> Result<MyTag, D::Error> {
+            let tag = try!(Deserialize::deserialize(deserializer));
+            Ok(MyTag {
+                num: tag,
+                data: try!(Deserialize::deserialize(deserializer)),
+            })
+        }
+    }
+    impl Serialize for MyTag {
+        fn serialize<S>(&self, serializer: &mut S) -> Result<(), S::Error>
+            where S: serde::Serializer,
+        {
+            CborTagEncode::new(self.num, &self.data).serialize(serializer)
+        }
+    }
+    fn prop(num: u64, data: Vec<i32>) -> bool {
+        round_trip(MyTag { num: num, data: data })
+    }
+    QuickCheck::new().quickcheck(prop as fn(u64, Vec<i32>) -> bool)
+}
+
+#[test]
+fn roundtrip_tag_fancier_data() {
+    #[derive(Debug, PartialEq, Deserialize, Serialize)]
+    struct DataName(Vec<u8>);
+
+    #[derive(Debug, PartialEq)]
+    struct CustomData {
+        name: DataName,
+        value: Vec<u8>,
+    }
+
+    impl Deserialize for CustomData {
+        fn deserialize<D: de::Deserializer>(d: &mut D) -> Result<CustomData, D::Error> {
+            let _ = try!(u64::deserialize(d));
+            let (name, value) = try!(de::Deserialize::deserialize(d));
+            Ok(CustomData { name: name, value: value })
+        }
+    }
+    impl Serialize for CustomData {
+        fn serialize<S: ser::Serializer>(&self, s: &mut S) -> Result<(), S::Error> {
+            CborTagEncode::new(100_000, &(&self.name, &self.value)).serialize(s)
+        }
+    }
+    assert!(round_trip(CustomData {
+        name: DataName(b"hello".to_vec()),
+        value: vec![1, 2, 3, 4, 5],
+    }));
+}
+
+#[test]
+fn rpc_decode() {
+    #[derive(Deserialize, Serialize)]
+    struct Message {
+        id: i64,
+        method: String,
+        params: CborBytes,
+    }
+
+    let send = cbor::serialize(Message {
+        id: 123,
+        method: "foobar".to_owned(),
+        params: CborBytes(cbor::serialize(("val".to_owned(), true, -5,))),
+    });
+    let msg: Message = cbor::deserialize(&send).unwrap();
+
+    assert_eq!(msg.method, "foobar");
+    let (val1, val2, val3): (String, bool, i32) = cbor::deserialize(&msg.params.0).unwrap();
+    assert_eq!(val1, "val");
+    assert_eq!(val2, true);
+    assert_eq!(val3, -5);
+}
+
+#[test]
+fn test_oom() {
+   let bad = vec![155u8, 0x00, 0xFF, 0xFF, 0xFF, 0x00, 0xFF, 0xFF, 0xFF];
+   let mut dec: cbor::CborResult<Vec<u32>> = cbor::deserialize(&bad);
+   assert!(dec.is_err());
+}
+
+// #[test]
+// fn test_oom_direct() {
+   // let bad = vec![155u8, 0x00, 0xFF, 0xFF, 0xFF, 0x00, 0xFF, 0xFF, 0xFF];
+   // assert!(Vec::<u32>::decode(&mut DirectDecoder::from_bytes(bad)).is_err());
+// }

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -26,11 +26,6 @@ fn round_trip<T>(v: T) -> bool
     true
 }
 
-#[allow(dead_code)]
-fn readone(bytes: &[u8]) -> Cbor {
-    Decoder::from_bytes(bytes).items().next().unwrap().unwrap()
-}
-
 macro_rules! round_trip_num {
     ($name:ident, $ty:ident) => (
         #[test]


### PR DESCRIPTION
Hello!

This PR adds initial support for serde. One of the cool things about it is that it can directly deserialize into a structure instead of having to go through `cbor::Decoder` to parse out a `Cbor` type and then deserialize from that into a `cbor::RustcDecoder`. It currently passes the tests and benchmarks pretty well (although it's still slower than serde_json for some unknown reason):

```
     Running target/release/bench-d76ac9f7d864696a

running 16 tests
test decode_medium_cbor        ... bench:  15,151,437 ns/iter (+/- 1,104,258) = 26 MB/s
test decode_medium_direct_cbor ... bench:   4,477,213 ns/iter (+/- 511,434) = 89 MB/s
test decode_medium_json        ... bench:  20,373,353 ns/iter (+/- 2,205,575) = 27 MB/s
test decode_small_cbor         ... bench:       1,315 ns/iter (+/- 37) = 30 MB/s
test decode_small_direct_cbor  ... bench:       2,558 ns/iter (+/- 345) = 15 MB/s
test decode_small_json         ... bench:       1,880 ns/iter (+/- 367) = 29 MB/s
test encode_medium_cbor        ... bench:     945,316 ns/iter (+/- 16,675) = 422 MB/s
test encode_medium_json        ... bench:   7,628,975 ns/iter (+/- 339,718) = 74 MB/s
test encode_medium_tojson      ... bench:  14,429,221 ns/iter (+/- 1,244,292) = 39 MB/s
test encode_small_cbor         ... bench:       3,460 ns/iter (+/- 359) = 11 MB/s
test encode_small_json         ... bench:         841 ns/iter (+/- 318) = 66 MB/s
test encode_small_tojson       ... bench:       1,213 ns/iter (+/- 202) = 46 MB/s
test read_medium_cbor          ... bench:   9,462,908 ns/iter (+/- 1,028,207) = 42 MB/s
test read_medium_json          ... bench:  14,876,985 ns/iter (+/- 2,433,638) = 38 MB/s
test read_small_cbor           ... bench:         785 ns/iter (+/- 193) = 50 MB/s
test read_small_json           ... bench:       1,226 ns/iter (+/- 26) = 45 MB/s

test result: ok. 0 passed; 0 failed; 0 ignored; 16 measured

     Running target/release/bench_serde-7de34a6bd2bc4f3a

running 8 tests
test deserialize_medium_cbor ... bench:   6,434,673 ns/iter (+/- 412,666) = 62 MB/s
test deserialize_medium_json ... bench:   4,808,781 ns/iter (+/- 1,297,244) = 117 MB/s
test deserialize_small_cbor  ... bench:       2,666 ns/iter (+/- 891) = 15 MB/s
test deserialize_small_json  ... bench:         439 ns/iter (+/- 16) = 127 MB/s
test serialize_medium_cbor   ... bench:   1,421,697 ns/iter (+/- 475,204) = 281 MB/s
test serialize_medium_json   ... bench:   4,730,402 ns/iter (+/- 1,666,983) = 120 MB/s
test serialize_small_cbor    ... bench:       3,479 ns/iter (+/- 491) = 11 MB/s
test serialize_small_json    ... bench:         441 ns/iter (+/- 122) = 126 MB/s

test result: ok. 0 passed; 0 failed; 0 ignored; 8 measured

     Running target/release/cbor-8d79df739e5d6e87

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured
```

Along the way I also changed how variants are serialized. Instead of `{"variant": "Name", "fields": [...]}`, it's now `{"Name": [...]}`. This is much more efficient for serde to parse because it doesn't require potentially buffering the field argument.

Be aware though that this does add a testing dependency to `serde_macros`, which is currently nightly-only. Check out how `serde_tests` in https://githb.com/serde-rs/serde if you're interested in a method that's compatible with stable rust.
