### PR TITLE
Non string keys

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -222,6 +222,27 @@ impl Type {
     }
 }
 
+/// Helper enum for the CBOR types that are permitted as map keys.
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub enum CborMapKey {
+    /// An unsigned integer key type.
+    UnsignedInteger(CborUnsigned),
+    /// A signed integer key type.
+    SignedInteger(CborSigned),
+    /// A Unicode string key type.
+    TextString(String),
+}
+
+impl Encodable for CborMapKey {
+    fn encode<E: RustcEncoder>(&self, e: &mut E) -> Result<(), E::Error>{
+        match *self {
+            CborMapKey::UnsignedInteger(v) => v.encode(e),
+            CborMapKey::SignedInteger(v) => v.encode(e),
+            CborMapKey::TextString(ref v) => v.encode(e),
+        }
+    }
+}
+
 /// CBOR abstract syntax.
 ///
 /// This type can represent any data item described in the CBOR specification
@@ -252,13 +273,13 @@ pub enum Cbor {
     /// An array (major type 4).
     Array(Vec<Cbor>),
     /// A map (major type 5).
-    Map(HashMap<String, Cbor>),
+    Map(HashMap<CborMapKey, Cbor>),
     /// A tag (major type 6).
     Tag(CborTag),
 }
 
 /// An unsigned integer (major type 0).
-#[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd, RustcDecodable)]
+#[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd, RustcDecodable, Hash)]
 pub enum CborUnsigned {
     /// Unsigned 8 bit integer.
     UInt8(u8),
@@ -276,7 +297,7 @@ pub enum CborUnsigned {
 /// CBOR `uint8`, it is outside the range of numbers allowed in `i8`.
 /// Therefore, when CBOR data is decoded, `-225` is stored as in `i16` in
 /// memory.
-#[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd, RustcDecodable)]
+#[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd, RustcDecodable, Hash)]
 pub enum CborSigned {
     /// Negative 8 bit integer.
     Int8(i8),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -222,7 +222,7 @@ impl Type {
     }
 }
 
-/// Helper enum for the CBOR types that are permitted as map keys.
+/// Helper enum for the CBOR types that are currently supported as map keys.
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub enum CborMapKey {
     /// An unsigned integer key type.

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -251,6 +251,8 @@ fn return_error_on_incomplete_read() {
 
 #[test]
 fn test_decode_non_string_map_key() {
+    // This should decode to a map with a single key that is the signed integer -1
+    // mapping to the value of the unsigned integer 7.
     let data = vec![0xa1, 0x01, 0x26];
     let mut decoder = Decoder::from_bytes(data);
     let map = decoder.items().next().unwrap();


### PR DESCRIPTION
This addresses #13 by adding signed/unsigned integer map key support (not sure it makes sense to support absolutely every CBOR type as map keys).
It's a first pass, so this is more of a feedback request to see if you think this is going in the right direction.
I can also add more tests.