### PR TITLE
Expose and document read_data_item.

### DIFF
--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -98,7 +98,8 @@ impl<R: io::Read> Decoder<R> {
         Items { dec: self }
     }
 
-    fn read_data_item(&mut self, first: Option<u8>) -> CborResult<Cbor> {
+    /// Reads a data item.
+    pub fn read_data_item(&mut self, first: Option<u8>) -> CborResult<Cbor> {
         let first = match first {
             Some(first) => first,
             None => try!(self.rdr.read_u8()),


### PR DESCRIPTION
Hi,

I'm using `read_data_item` directly and it would be cool if it were public.

```rust
pub(crate) fn decode(bytes: Vec<u8>) -> Result<Ipld, IpldError> {
    let mut d = Decoder::from_bytes(bytes);
    let cbor: Cbor = d.read_data_item(None)?;
    cbor_to_ipld(cbor)
}
```